### PR TITLE
Add initial Node API scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Time Management Achievers (TMA)
+
+This repository holds early scaffolding for the **TMA** project described in SPEC-001.  
+
+## Backend
+
+- Minimal Node HTTP server exposing `/api/tasks`.
+- Supports idempotent `POST /api/tasks` where repeating the same `id` returns existing data.
+- `GET /api/tasks` lists stored tasks (in memory for now).
+
+Run tests:
+
+```bash
+cd backend
+npm test
+```
+
+## Next Steps
+
+- Expand REST endpoints for projects, goals, sessions and more per SPEC-001.
+- Add persistence via Supabase/Postgres.
+- Implement PWA front-end with planning and Pomodoro timer.

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,48 @@
+const http = require('http');
+const { URL } = require('url');
+
+const port = 3000;
+const tasks = new Map();
+
+function sendJson(res, status, obj) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(obj));
+}
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+
+  if (url.pathname === '/api/tasks' && req.method === 'GET') {
+    return sendJson(res, 200, Array.from(tasks.values()));
+  }
+
+  if (url.pathname === '/api/tasks' && req.method === 'POST') {
+    let body = '';
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', () => {
+      try {
+        const data = JSON.parse(body || '{}');
+        const id = data.id;
+        if (!id) {
+          return sendJson(res, 400, { error: 'id required' });
+        }
+        if (tasks.has(id)) {
+          return sendJson(res, 200, tasks.get(id));
+        }
+        tasks.set(id, data);
+        return sendJson(res, 201, data);
+      } catch (err) {
+        return sendJson(res, 400, { error: 'invalid json' });
+      }
+    });
+    return;
+  }
+
+  sendJson(res, 404, { error: 'Not found' });
+});
+
+if (require.main === module) {
+  server.listen(port, () => console.log(`Server listening on ${port}`));
+}
+
+module.exports = server;

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "TMA API server",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "test": "node test.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/backend/test.js
+++ b/backend/test.js
@@ -1,0 +1,30 @@
+const server = require('./index');
+const assert = require('assert');
+
+async function run() {
+  await new Promise(resolve => server.listen(0, resolve));
+  const port = server.address().port;
+  const base = `http://localhost:${port}`;
+
+  const createRes = await fetch(`${base}/api/tasks`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ id: '1', title: 'Test Task' })
+  });
+  assert.strictEqual(createRes.status, 201);
+
+  const listRes = await fetch(`${base}/api/tasks`);
+  const tasks = await listRes.json();
+  assert.strictEqual(listRes.status, 200);
+  assert.strictEqual(tasks.length, 1);
+  assert.strictEqual(tasks[0].title, 'Test Task');
+
+  server.close();
+  console.log('All tests passed');
+}
+
+run().catch(err => {
+  console.error(err);
+  server.close();
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- set up a minimal Node HTTP server exposing `/api/tasks`
- document project goals and backend in README
- add basic test to confirm task creation and retrieval

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad312b531c832889d73817da8de3bb